### PR TITLE
Fix teapot error

### DIFF
--- a/sources/web/.htaccess
+++ b/sources/web/.htaccess
@@ -54,12 +54,10 @@
 # Declare custom error pages
 ErrorDocument 403 /error/403
 ErrorDocument 404 /error/404
-ErrorDocument 418 /error/418
 
 # Handle errors
 <IfModule mod_rewrite.c>
     RewriteRule ^error/([4|5][0-9]{2})$ error/index.php?code=$1 [L]
-    RewriteRule ^teapot$ /error/418 [L]
 </IfModule>
 
 ### Security ###

--- a/sources/web/error/index.php.mustache
+++ b/sources/web/error/index.php.mustache
@@ -3,7 +3,6 @@ $user_url = $_SERVER["REQUEST_URI"];
 $statuses = array(
     403 => "You don't have access to this resource",
     404 => "The requested URL \"$user_url\" was not found",
-    418 => "Don't brew coffee in a teapot",
 );
 
 $status = $_GET["code"];

--- a/tests/ServerTests/RedirectionTests.swift
+++ b/tests/ServerTests/RedirectionTests.swift
@@ -114,22 +114,6 @@ extension RedirectionTests {
             XCTAssertTrue(expected.contains { $0 == status }, "For \($0.1) got \(status ?? 0)")
         }
     }
-
-    func testTeapot() {
-        // given
-        let locations = [
-            "teapot",
-            ].map { "/" + $0 }
-            .flatMap { self.combinations(for: $0) }
-
-        // when
-        let responses = locations.map { self.request(url: $0).headers.last }
-
-        // then
-        zip(responses, locations).forEach {
-            XCTAssertEqual($0.0?.status, 418, "For \($0.1)")
-        }
-    }
 }
 
 // MARK: - Content for files


### PR DESCRIPTION
This PR removes teapot HTTP error code handling. 
This error caused 500 errors on production server, namely line `ErrorDocument 418 /error/418` from root `.htaccess`.